### PR TITLE
Fix build and bump dependency on 'bound'.

### DIFF
--- a/ermine.cabal
+++ b/ermine.cabal
@@ -139,7 +139,7 @@ library
     base                      >= 4       && < 5,
     bifunctors                == 3.*,
     binary                    == 0.5.*,
-    bound                     >= 0.8     && < 1,
+    bound                     >= 0.8.1   && < 1,
     bytes                     >= 0.8     && < 1,
     bytestring                >= 0.9     && < 0.11,
     cereal                    >= 0.3.5.2 && < 0.4,

--- a/src/Ermine/Inference/Type.hs
+++ b/src/Ermine/Inference/Type.hs
@@ -24,6 +24,7 @@ module Ermine.Inference.Type
   ) where
 
 import Bound
+import Bound.Var
 import Control.Applicative
 import Control.Comonad
 import Control.Lens

--- a/src/Ermine/Syntax/Kind.hs
+++ b/src/Ermine/Syntax/Kind.hs
@@ -35,6 +35,7 @@ module Ermine.Syntax.Kind
 
 import Bound
 import Bound.Scope
+import Bound.Var
 import Control.Applicative
 import Control.Lens
 import Control.Monad

--- a/src/Ermine/Syntax/Scope.hs
+++ b/src/Ermine/Syntax/Scope.hs
@@ -16,8 +16,6 @@ module Ermine.Syntax.Scope
   ( hoistScope
   , bitraverseScope
   , transverseScope
-  , _B
-  , _F
   , BoundBy(..)
   , instantiateVars
   -- , putVar , getVar , putScope, getScope
@@ -56,20 +54,6 @@ transverseScope :: (Applicative f, Monad f, Traversable g)
                 => (forall r. g r -> f (h r))
                 -> Scope b g a -> f (Scope b h a)
 transverseScope tau (Scope e) = Scope <$> (tau =<< traverse (traverse tau) e)
-
--- | This prism acts like a reversible smart constructor for 'B'.
-_B :: Prism (Var a c) (Var b c) a b
-_B = prism B $ \ t -> case t of
-  B b -> Right b
-  F c -> Left (F c)
-{-# INLINE _B #-}
-
--- | This prism acts like a reversible smart constructor for 'F'.
-_F :: Prism (Var c a) (Var c b) a b
-_F = prism F $ \ t -> case t of
-  B c -> Left (B c)
-  F b -> Right b
-{-# INLINE _F #-}
 
 -- | instantiate bound variables using a list of new variables
 instantiateVars :: Monad t => [a] -> Scope Int t a -> t a


### PR DESCRIPTION
bound 0.8.1 already has prisms for `_F` and `_B` - the definitions in the Scope module then conflict if you have 0.8.1 installed.
