### PR TITLE
Needed to hide Control.Lens.matching because of a name-conflict with Erm...

### DIFF
--- a/src/Ermine/Pattern/Matching.hs
+++ b/src/Ermine/Pattern/Matching.hs
@@ -42,7 +42,7 @@ import Bound
 import Bound.Scope
 import Control.Applicative
 import Control.Comonad
-import Control.Lens
+import Control.Lens hiding (matching)
 import Control.Monad.Trans (lift)
 import Data.Either (partitionEithers)
 import Data.Foldable hiding (concatMap)


### PR DESCRIPTION
...ine.Pattern.Matching.matching.

The following error occurred on GHC-7.8.3-2 with lens 4.3.

```
src/Ermine/Pattern/Matching.hs:88:1:
    Ambiguous occurrence ‘matching’
    It could refer to either ‘Ermine.Pattern.Matching.matching’,
                             defined at src/Ermine/Pattern/Matching.hs:88:1
                          or ‘Control.Lens.matching’,
                             imported from ‘Control.Lens’ at src/Ermine/Pattern/Matching.hs:45:1-19
                             (and originally defined in ‘Control.Lens.Prism’)

src/Ermine/Pattern/Matching.hs:88:1:
    Ambiguous occurrence ‘matching’
    It could refer to either ‘Ermine.Pattern.Matching.matching’,
                             defined at src/Ermine/Pattern/Matching.hs:88:1
                          or ‘Control.Lens.matching’,
                             imported from ‘Control.Lens’ at src/Ermine/Pattern/Matching.hs:45:1-19
                             (and originally defined in ‘Control.Lens.Prism’)

src/Ermine/Pattern/Matching.hs:88:1:
    Ambiguous occurrence ‘matching’
    It could refer to either ‘Ermine.Pattern.Matching.matching’,
                             defined at src/Ermine/Pattern/Matching.hs:88:1
                          or ‘Control.Lens.matching’,
                             imported from ‘Control.Lens’ at src/Ermine/Pattern/Matching.hs:45:1-19
                             (and originally defined in ‘Control.Lens.Prism’)
cabal: Error: some packages failed to install:
ermine-0.6 failed during the building phase. The exception was:
ExitFailure 1
```
